### PR TITLE
Maestro Restart + URI Bug Fixes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,7 @@ HELP_TEXT = <<~HELP_TEXT.freeze
   `/maestro pause` -- Pauses (or resumes) Spotify playback.
   `/maestro stop` -- Stops playback.
   `/maestro quit` -- Stops playback and quits Spotify.
+  `/maestro restart` -- Quits and restarts Spotify.
 
   `/maestro vol up` -- Increases the volume by 10%.
   `/maestro vol down` -- Decreases the volume by 10%.

--- a/app.rb
+++ b/app.rb
@@ -22,7 +22,7 @@ HELP_TEXT = <<~HELP_TEXT.freeze
   `/maestro vol up` -- Increases the volume by 10%.
   `/maestro vol down` -- Decreases the volume by 10%.
   `/maestro vol <amount>` -- Sets the volume to an amount between 0 and 100.
-  `/maestro vol [show]` -- Shows the current Spotify volume.
+  `/maestro vol` -- Shows the current Spotify volume.
 
   `/maestro status` -- Shows the current player status.
 
@@ -38,9 +38,8 @@ HELP_TEXT
 VALID_COMMANDS = (Spotify.public_methods - Object.public_methods).freeze
 
 def process_spotify_command(args)
-  args.downcase!
   command, *params = *split_args(args)
-  command = command.to_sym
+  command = command.downcase.to_sym
   return [HELP_TEXT, true] if args == "help" || !VALID_COMMANDS.include?(command)
   Spotify.public_send(*format_params(command, params))
 end

--- a/spec/maestro_spec.rb
+++ b/spec/maestro_spec.rb
@@ -50,7 +50,7 @@ describe "Maestro" do
 
   describe "Valid command" do
     context "command with no args" do
-      let(:text) { "stop" }
+      let(:text) { "Stop" }
       let(:expected_command) { :stop }
 
       it_behaves_like "a valid maestro command"
@@ -66,6 +66,16 @@ describe "Maestro" do
         it_behaves_like "a valid maestro command" do
           let(:expected_args) { time }
         end
+      end
+    end
+
+    context "with a uri" do
+      let(:text) { "play uri #{uri}" }
+      let(:expected_command) { :play }
+      let(:uri) { "spotify:track:6n50vexd6yBNvSOc6QHT5X" }
+
+      it_behaves_like "a valid maestro command" do
+        let(:expected_args) {  "uri #{uri}" }
       end
     end
   end

--- a/spec/maestro_spec.rb
+++ b/spec/maestro_spec.rb
@@ -50,7 +50,14 @@ describe "Maestro" do
 
   describe "Valid command" do
     context "command with no args" do
-      let(:text) { "Stop" }
+      let(:text) { "stop" }
+      let(:expected_command) { :stop }
+
+      it_behaves_like "a valid maestro command"
+    end
+
+    context "mixed case" do
+      let(:text) { "sToP" }
       let(:expected_command) { :stop }
 
       it_behaves_like "a valid maestro command"

--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -6,9 +6,9 @@ require_relative "../app"
 require_relative "../spotify"
 
 describe "Spotify" do
-  shared_examples_for "a valid command" do
-    let(:command_stub) { `echo 'hello'` } # Prevent RSpec from executing real commands
+  let(:command_stub) { `echo 'hello'` } # Prevent RSpec from executing real commands
 
+  shared_examples_for "a valid command" do
     it "executes the correct Shpotify command" do
       expect(Spotify).to receive(:`).with(expected_command).and_return(command_stub)
       subject
@@ -30,6 +30,13 @@ describe "Spotify" do
   describe ".stop" do
     subject { Spotify.stop }
     let(:expected_command) { "./spotify.sh stop" }
+
+    it_behaves_like "a valid command"
+  end
+
+  describe ".pause" do
+    subject { Spotify.pause }
+    let(:expected_command) { "./spotify.sh pause" }
 
     it_behaves_like "a valid command"
   end
@@ -130,7 +137,7 @@ describe "Spotify" do
 
     context "uri" do
       let(:share_args) { "uri" }
-      let(:expected_command) { "./spotify.sh share uri" }
+      let(:expected_command) { "./spotify.sh share #{share_args}" }
 
       it_behaves_like "a valid command"
     end
@@ -138,6 +145,37 @@ describe "Spotify" do
     context "url" do
       let(:share_args) { "url" }
       let(:expected_command) { "./spotify.sh share url" }
+
+      it_behaves_like "a valid command"
+    end
+  end
+
+  describe ".toggle" do
+    subject { Spotify.toggle(toggle_args) }
+    let(:expected_command) { "./spotify.sh toggle #{toggle_args}".rstrip }
+
+    context "empty string" do
+      let(:toggle_args) { "" }
+
+      it_behaves_like "an invalid command"
+    end
+
+    context "invalid toggle" do
+      let(:toggle_args) { "invalid" }
+
+      it_behaves_like "an invalid command"
+    end
+
+    context "shuffle" do
+      let(:toggle_args) { "shuffle" }
+      let(:expected_command) { "./spotify.sh toggle #{toggle_args}" }
+
+      it_behaves_like "a valid command"
+    end
+
+    context "repeat" do
+      let(:toggle_args) { "repeat" }
+      let(:expected_command) { "./spotify.sh toggle repeat" }
 
       it_behaves_like "a valid command"
     end
@@ -189,6 +227,27 @@ describe "Spotify" do
       let(:play_args) { "list some_playlist; curl malwarehost.com" }
 
       it_behaves_like "an invalid command"
+    end
+  end
+
+  describe ".quit" do
+    subject { Spotify.quit }
+    let(:expected_command) { "./spotify.sh quit" }
+
+    it_behaves_like "a valid command"
+  end
+
+  describe ".restart" do
+    subject { Spotify.restart }
+    let(:quit) { "./spotify.sh quit" }
+    let(:open) { "open #{Spotify::APP_PATH}" }
+
+    before { allow(Spotify).to receive(:sleep) }
+
+    it "restarts Spotify" do
+      expect(Spotify).to receive(:`).with(quit).once
+      expect(Spotify).to receive(:`).with(open).once.and_return(command_stub)
+      subject
     end
   end
 end

--- a/spotify.rb
+++ b/spotify.rb
@@ -1,4 +1,5 @@
 class Spotify
+  APP_PATH = "/Applications/Spotify.app".freeze # TODO: Make this configurable
   VALID_TOGGLES = %w(shuffle repeat).freeze
   VALID_SHARES = %w(url uri).freeze
   NAME_REGEX = /\A(artist|album|list) [a-z0-9\.\-_\s]*\z/i
@@ -15,7 +16,11 @@ class Spotify
   class << self
     def play(play_args = "")
       return invalid_command unless valid_play?(play_args)
-      send_command("play #{play_args}".rstrip)
+      send_command("play #{play_args}")
+    end
+
+    def pause
+      send_command("pause")
     end
 
     def stop
@@ -34,14 +39,21 @@ class Spotify
       send_command("replay")
     end
 
+    def restart
+      quit
+      sleep(5) # Give Spotify a few seconds to shut down
+      `open #{APP_PATH}`
+      output = $?.success? ? "Spotify has been restarted" : "I had some trouble restarting Spotify"
+      [output, $?.success?]
+    end
+
     def pos(time)
       return invalid_command unless time == time.to_i
       send_command("pos #{time.to_i}")
     end
 
-    def vol(change = "")
-      return invalid_command unless valid_volume_change?(change)
-      send_command("vol #{change}".rstrip)
+    def quit
+      send_command("quit")
     end
 
     def status
@@ -50,13 +62,23 @@ class Spotify
 
     def share(share_item)
       return invalid_command unless valid_share?(share_item)
-      send_command("share #{share_item}".rstrip) # Prevent extra whitespace
+      send_command("share #{share_item}")
+    end
+
+    def toggle(toggle_item)
+      return invalid_command unless valid_toggle?(toggle_item)
+      send_command("toggle #{toggle_item}")
+    end
+
+    def vol(change = "")
+      return invalid_command unless valid_volume_change?(change)
+      send_command("vol #{change}")
     end
 
     private
 
     def send_command(command)
-      output = `./spotify.sh #{command}`
+      output = `./spotify.sh #{command.rstrip}`
       output = HELP_TEXT unless $?.success?
       [output, $?.success?]
     end


### PR DESCRIPTION
### Why?
* It'd be awfully convenient to restart Spotify with a `/maestro restart` command.
* URIs are case sensitive and downcasing them triggers a bug in Spotify. We were downcasing everything.
* Some methods described in the help text were not available in the app.

### What Changed?
* Implemented `restart`, `pause`, `quit`, and `toggle`
* Fixed case-sensitivity bug when playing by URI