### PR TITLE
Properly validate volume arguments

### DIFF
--- a/spec/spotify_spec.rb
+++ b/spec/spotify_spec.rb
@@ -100,7 +100,8 @@ describe "Spotify" do
     end
 
     context "with a volume integer" do
-      let(:vol_args) { rand(0..100) }
+      # to_s since args come from app.rb as strings
+      let(:vol_args) { rand(0..100).to_s }
 
       it_behaves_like "a valid command"
     end

--- a/spotify.rb
+++ b/spotify.rb
@@ -88,8 +88,8 @@ class Spotify
     end
 
     def valid_volume_change?(vol_arg)
-      if vol_arg == vol_arg.to_i
-        vol_arg.between?(0, 100)
+      if vol_arg == vol_arg.to_i.to_s
+        vol_arg.to_i.between?(0, 100)
       else
         ["", "up", "down"].include?(vol_arg)
       end


### PR DESCRIPTION
### Why?
`/maestro vol <integer>` command was failing
Volume levels were coming in as strings and were not being validated properly

### What Changed?
Use `to_s` and `to_i` properly