### PR TITLE
Fix slash commands link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ new one.**
 
 ### Creating a slash command
 
-To create a slash command in Slack, go [here](https://api.slack.com/outgoing-webhooks) and fill in
+To create a slash command in Slack, go [here](https://api.slack.com/slash-commands) and fill in
 the following settings:
 
 - Command: "/maestro"


### PR DESCRIPTION
### Why?
- The slash commands link was pointing to the outgoing webhooks page.